### PR TITLE
resolved the redirection problem with Phoenix

### DIFF
--- a/lib/CaddyFile
+++ b/lib/CaddyFile
@@ -1,0 +1,5 @@
+localhost:443 {
+	handle {
+		reverse_proxy 127.0.0.1:4000
+	}
+}

--- a/lib/app.js
+++ b/lib/app.js
@@ -1,0 +1,11 @@
+// ...........
+
+import { facebook } from "./facebook";
+const csrfToken = document
+  .querySelector("meta[name='csrf-token']")
+  .getAttribute("content");
+
+// ..........
+
+const fbutton = document.getElementById("fbhook");
+if (fbutton) facebook(fbutton, csrfToken);

--- a/lib/facebook.js
+++ b/lib/facebook.js
@@ -13,7 +13,7 @@ export function facebook(fbutton, token) {
 
   window.fbAsyncInit = function () {
     FB.init({
-      appId: `${window.app_id}`,
+      appId: `${window.process_env}`,
       cookie: true,
       xfbml: false,
       version: "v15.0",
@@ -28,25 +28,13 @@ export function facebook(fbutton, token) {
 
   function statusChangeCallback(response) {
     if (response.status === "connected") {
-      testAPI();
+      graphAPI();
     } else {
       startDialog();
     }
   }
 
-  function testAPI() {
-    FB.api("/me?fields=id,email,name,picture", async function (response) {
-      return fetch("/auth/fbsdk", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-CSRF-Token": token,
-        },
-        body: JSON.stringify(response),
-      }).catch((err) => console.log(err));
-    });
-  }
-
+  // starting the Dialog form
   function startDialog() {
     FB.login(
       function (response) {
@@ -56,5 +44,20 @@ export function facebook(fbutton, token) {
       },
       { scope: "public_profile,email" }
     );
+  }
+
+  // we query FB's graph and redirect passing the query string
+  function graphAPI() {
+    FB.api("/me?fields=id,email,name,picture", async function (response) {
+      const url = `/auth/fbk/sdk?${build(response)}`;
+      return (window.location.href = url);
+    });
+  }
+
+  // we build the query string
+  function build(response) {
+    response.picture = JSON.stringify(response.picture.data);
+    const params = new URLSearchParams(response);
+    return params.toString();
   }
 }

--- a/lib/facebook_sdk_auth_controller.ex
+++ b/lib/facebook_sdk_auth_controller.ex
@@ -1,0 +1,47 @@
+defmodule MyAppWeb.FacebookSdkAuthController do
+  use MyAppWeb, :controller
+
+  action_fallback(MyAppWeb.LoginError)
+
+  # obtain an atom-key based map from a string-key  based map
+  defp into_atoms(strings) do
+    for {k, v} <- strings, into: %{}, do: {String.to_atom(k), v}
+  end
+
+  # update a nested key
+  defp into_deep(params, key) do
+    params
+    |> into_atoms()
+    |> Map.update!(key, fn pic ->
+      pic
+      |> Jason.decode!()
+      |> into_atoms()
+    end)
+  end
+
+  def handle(conn, params) do
+    profile = into_deep(params, :picture)
+
+    # below is an example of handling the obtained "profile"
+    # you save to the database and put the data in the session
+    # ( I used a Repo.insert with an "on_conflict" and "conflict_target" clause
+    # instead of a find_or_create...)
+
+    case profile do
+      %{email: email} ->
+        # you want to pass the name or email and ID
+        user = MyApp.User.new(email)
+        user_token = MyApp.Token.user_generate(user.id)
+
+        conn
+        |> fetch_session()
+        |> put_session(:user_token, user_token)
+        |> put_session(:user_id, user.id)
+        |> put_session(:origin, "fb_sdk")
+        |> put_session(:profile, profile)
+        |> put_view(MyAppWeb.WelcomeView)
+        |> redirect(to: "/welcome")
+        |> halt()
+    end
+  end
+end

--- a/lib/fb_sdk_auth_controller.ex
+++ b/lib/fb_sdk_auth_controller.ex
@@ -1,9 +1,0 @@
-defmodule MyAppWeb.FbSdkAuthController do
-  use LiveMapWeb, :controller
-
-  def handle(conn, params) do
-    profile = for {k, v} <- params, into: %{}, do: {String.to_atom(k), v}
-    conn
-    #  ... process the profile and continue the rendering
-  end
-end

--- a/lib/router.ex
+++ b/lib/router.ex
@@ -1,0 +1,12 @@
+# .........
+
+scope "/auth", LiveMapWeb do
+  pipe_through(:browser)
+
+  get("/google/callback", GoogleAuthController, :index)
+  get("/github/callback", GithubAuthController, :index)
+  get("/facebook/callback", FacebookAuthController, :login)
+
+  # this is the new route
+  get("/fbk/sdk", FacebookSdkAuthController, :handle)
+end


### PR DESCRIPTION
This is corrected and tested  "SDK based" Facebook login.

This means it is a browser-based solution and uses the Facebook JS library.

I had to modify the way I was sending data to the Phoenix server because it didn't render HTML.

I now make a redirection from the browser and pass the data in a query string (HTTPS).

The controller is a simple 'GET' endpoint.

It parses the data into an easy-to-use atom-key map, 

and is ready to follow you where you want now.

To use it, you will need to simulate a localhost on HTTPS. 
Caddyserver does this VERY easily.

If you want to test it, the app id starts with two, then add 37650989916311 and add a nine at the end.